### PR TITLE
refactor: Refactor Mongoose Type References to Use Full Interface Objects

### DIFF
--- a/src/model/accessor.ts
+++ b/src/model/accessor.ts
@@ -4,7 +4,7 @@ import { IBaseModel, baseSchema } from './base.model'
 import { IUser } from './user'
 
 interface IAccessor extends IBaseModel {
-  accessor: mongoose.Types.ObjectId | IUser['_id']
+  accessor: mongoose.Types.ObjectId | IUser
   modelId: mongoose.Types.ObjectId
 }
 

--- a/src/model/installment.ts
+++ b/src/model/installment.ts
@@ -12,7 +12,7 @@ interface IInstallment extends IBaseTransaction {
   startDate: Date
   endDate: Date
 
-  transactions: mongoose.Types.ObjectId[] | ITransaction['_id'][]
+  transactions: mongoose.Types.ObjectId[] | ITransaction[]
 
   remainingAmount: number
   getRemainingAmount(): Promise<number>

--- a/src/model/subscription.ts
+++ b/src/model/subscription.ts
@@ -12,7 +12,7 @@ interface ISubscription extends IBaseTransaction {
   startDate: Date
   endDate: Date
 
-  transactions: mongoose.Types.ObjectId[] | ITransaction['_id'][]
+  transactions: mongoose.Types.ObjectId[] | ITransaction[]
 
   nextPaymentDate: Date
   getNextPaymentDate(): Promise<Date>

--- a/src/model/transaction-base.ts
+++ b/src/model/transaction-base.ts
@@ -13,12 +13,12 @@ interface IBaseTransaction extends IBaseModel {
   direction: 'income' | 'expense'
   amount: number
 
-  category: mongoose.Types.ObjectId | ITransactionCategory['_id']
+  category: mongoose.Types.ObjectId | ITransactionCategory
 
-  brand: mongoose.Types.ObjectId | ITransactionBrand['_id']
+  brand: mongoose.Types.ObjectId | ITransactionBrand
 
-  wallet: mongoose.Types.ObjectId | IWallet['_id']
-  walletBalance: mongoose.Types.ObjectId | IWalletBalance['_id']
+  wallet: mongoose.Types.ObjectId | IWallet
+  walletBalance: mongoose.Types.ObjectId | IWalletBalance
 }
 
 const baseTransactionSchema = new mongoose.Schema({

--- a/src/model/transaction.ts
+++ b/src/model/transaction.ts
@@ -8,11 +8,7 @@ import { baseTransactionSchema, IBaseTransaction } from './transaction-base'
 
 interface ITransaction extends IBaseTransaction {
   type: 'single' | 'installment' | 'subscription'
-  parent:
-    | mongoose.Schema.Types.ObjectId
-    | IInstallment['_id']
-    | ISubscription['_id']
-    | null
+  parent: mongoose.Schema.Types.ObjectId | IInstallment | ISubscription | null
   transactionStatus: 'pending' | 'paid' | 'overdue' | 'canceled'
   link: string
   dueDate: Date

--- a/src/model/wallet-accessor.ts
+++ b/src/model/wallet-accessor.ts
@@ -7,9 +7,9 @@ import { IWallet } from './wallet'
 interface IWalletAccessor extends IBaseModel {
   walletAccessorStatus: 'active' | 'pending'
 
-  accessor: mongoose.Types.ObjectId | IUser['_id']
+  accessor: mongoose.Types.ObjectId | IUser
 
-  wallet: mongoose.Types.ObjectId | IWallet['_id']
+  wallet: mongoose.Types.ObjectId | IWallet
 }
 
 const walletAccessorSchema = new mongoose.Schema({

--- a/src/model/wallet-balance.ts
+++ b/src/model/wallet-balance.ts
@@ -10,9 +10,9 @@ interface IWalletBalance extends IBaseModel {
   amount: number
   currency: string
 
-  wallet: mongoose.Types.ObjectId | IWallet['_id']
+  wallet: mongoose.Types.ObjectId | IWallet
 
-  transactions: mongoose.Types.ObjectId[] | ITransaction['_id'][]
+  transactions: mongoose.Types.ObjectId[] | ITransaction[]
 }
 
 const walletBalanceSchema = new mongoose.Schema({

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -13,10 +13,10 @@ interface IWallet extends IBaseModel {
   design: string
   platform: string
 
-  walletType: mongoose.Types.ObjectId | IWalletType['_id']
+  walletType: mongoose.Types.ObjectId | IWalletType
 
-  walletBalances: mongoose.Types.ObjectId[] | IWalletBalance['_id'][]
-  accessors: mongoose.Types.ObjectId[] | IWalletAccessor['_id'][]
+  walletBalances: mongoose.Types.ObjectId[] | IWalletBalance[]
+  accessors: mongoose.Types.ObjectId[] | IWalletAccessor[]
 
   getTotalBalance(): Promise<number>
 

--- a/src/model/wishlist-accessor.ts
+++ b/src/model/wishlist-accessor.ts
@@ -6,8 +6,8 @@ import { IWishlist } from './wishlist'
 
 interface IWishlistAccessor extends IBaseModel {
   wishlistAccessorStatus: 'active' | 'pending'
-  accessor: mongoose.Types.ObjectId | IUser['_id']
-  wishlist: mongoose.Types.ObjectId | IWishlist['_id']
+  accessor: mongoose.Types.ObjectId | IUser
+  wishlist: mongoose.Types.ObjectId | IWishlist
 }
 
 const wishlistAccessorSchema = new mongoose.Schema({

--- a/src/model/wishlist-item.ts
+++ b/src/model/wishlist-item.ts
@@ -13,10 +13,10 @@ interface IWishlistItem extends IBaseModel {
   price: number
   image: string
 
-  reservedBy: mongoose.Types.ObjectId | IUser['_id']
+  reservedBy: mongoose.Types.ObjectId | IUser
   reservedAt: Date
 
-  wishlist: mongoose.Types.ObjectId | IWishlist['_id']
+  wishlist: mongoose.Types.ObjectId | IWishlist
 }
 
 const WishlistItemSchema = new mongoose.Schema({

--- a/src/model/wishlist.ts
+++ b/src/model/wishlist.ts
@@ -12,8 +12,8 @@ interface IWishlist extends IBaseModel {
   isPublic: boolean
   isReservable: boolean
 
-  items: mongoose.Types.ObjectId[] | IWishlistItem['_id'][]
-  accessors: mongoose.Types.ObjectId[] | IAccessor['_id'][]
+  items: mongoose.Types.ObjectId[] | IWishlistItem[]
+  accessors: mongoose.Types.ObjectId[] | IAccessor[]
 }
 
 const wishlistSchema = new mongoose.Schema({


### PR DESCRIPTION
This pull request refactors the type definitions in our Mongoose models to improve type safety and provide better TypeScript intellisense. The primary change involves updating reference types from `ObjectId | ModelName['_id']` to `ObjectId | ModelName`, which allows for better type completion and safer operations when working with populated fields.

### Changes:

- Updated all model interface definitions to use complete interface types instead of just ID references
- Affected models:
  - `Accessor`
  - `Installment`
  - `Subscription`
  - `BaseTransaction`
  - `Transaction`
  - `WalletAccessor`
  - `WalletBalance`
  - `Wallet`
  - `WishlistAccessor`
  - `WishlistItem`
  - `Wishlist`

### Benefits:

- Improved TypeScript intellisense when working with populated documents
- Better type safety across the application
- Clearer code that more accurately reflects how Mongoose handles populated references
- No functional changes to runtime behavior, only TypeScript type improvements

### Testing:

These changes are type-only modifications and don't affect runtime behavior. The application should continue to function exactly as before with improved type safety.